### PR TITLE
feat: agrega validaciones required min max y feedback

### DIFF
--- a/generators/gui/guiService.js
+++ b/generators/gui/guiService.js
@@ -24,6 +24,7 @@ module.exports = class guiService {
       }
       secciones[seccion][subseccion].campos.push(this.formatCampo(campo));
     });
+    console.log(secciones);
     return secciones;
   }
 
@@ -132,18 +133,14 @@ module.exports = class guiService {
     const validations = {};
     validations.required = campo.requerido;
     validations.requiredValue = campo.requerido;
-    validations.requiredMessage = campo.mensajeRequerido;
     if (campo.min) {
       validations.min = campo.min;
-      validations.minMessage = campo.mensajeMin;
     }
     if (campo.max) {
       validations.max = campo.max;
-      validations.maxMessage = campo.mensajeMax;
     }
     if (campo.regex) {
       validations.regex = campo.regex;
-      validations.regexMessage = campo.mensajeRegex;
     }
     return validations;
   }

--- a/generators/gui/guiService.js
+++ b/generators/gui/guiService.js
@@ -67,6 +67,8 @@ module.exports = class guiService {
     campo.dashCase = String.toDashCase(campo.campo);
     campo.clientType = this.resolveClientType(campo.tipoUi);
     campo.clientDefaultValue = this.resolveDefaultValue(campo.tipoUi);
+    campo.feedback = campo.feedback ? campo.feedback : null;
+    campo.validations = this.resolveValidations(campo);
     return campo;
   }
 
@@ -122,5 +124,17 @@ module.exports = class guiService {
       return 'false';
     }
     return "''";
+  }
+
+  static resolveValidations(campo) {
+    let validations = {};
+    validations.required = campo.requerido;
+    if (campo.min) {
+      validations.min = campo.min;
+    }
+    if (campo.max) {
+      validations.max = campo.max;
+    }
+    return validations;
   }
 };

--- a/generators/gui/guiService.js
+++ b/generators/gui/guiService.js
@@ -154,7 +154,7 @@ module.exports = class guiService {
     if (campo.tipoUi === 'TextArea') {
       props.maxCaracteres = campo.maxCaracteres;
     }
-    if (campo.tipoUi === 'Date' && campo.minDate && campo.maxDate) {
+    if (campo.tipoUi === 'Date') {
       props.minDate = campo.minDate;
       props.maxDate = campo.maxDate;
     }

--- a/generators/gui/guiService.js
+++ b/generators/gui/guiService.js
@@ -158,7 +158,7 @@ module.exports = class guiService {
       props.maxDate = campo.maxDate;
     }
     if (campo.tipoUi === 'MultiSelect' || campo.tipoUi === 'selectMultiple') {
-      props.minimosRequeridos = campo.minimosRequeridos;
+      props.minimosRequeridos = campo.minimosRequeridos ? campo.minimosRequeridos : 1;
     }
     return props;
   }

--- a/generators/gui/guiService.js
+++ b/generators/gui/guiService.js
@@ -26,7 +26,6 @@ module.exports = class guiService {
       }
       secciones[seccion][subseccion].campos.push(this.formatCampo(campo));
     });
-    console.log(secciones);
     return secciones;
   }
 

--- a/generators/gui/guiService.js
+++ b/generators/gui/guiService.js
@@ -68,9 +68,9 @@ module.exports = class guiService {
     campo.constantCase = String.toConstantCase(campo.campo);
     campo.clientType = this.resolveClientType(campo.tipoUi);
     campo.clientDefaultValue = this.resolveDefaultValue(campo.tipoUi);
-    campo.feedback = campo.feedback ? campo.feedback : null;
     campo.description = campo.descripcion ? campo.descripcion : null;
     campo.validations = this.resolveValidations(campo);
+    campo.props = this.resolveProps(campo);
     return campo;
   }
 
@@ -129,7 +129,7 @@ module.exports = class guiService {
   }
 
   static resolveValidations(campo) {
-    let validations = {};
+    const validations = {};
     validations.required = campo.requerido;
     validations.requiredValue = campo.requerido;
     validations.requiredMessage = campo.mensajeRequerido;
@@ -146,5 +146,20 @@ module.exports = class guiService {
       validations.regexMessage = campo.mensajeRegex;
     }
     return validations;
+  }
+
+  static resolveProps(campo) {
+    const props = {};
+    if (campo.tipoUi === 'TextArea') {
+      props.maxCaracteres = campo.maxCaracteres;
+    }
+    if (campo.tipoUi === 'Date' && campo.minDate && campo.maxDate) {
+      props.minDate = campo.minDate;
+      props.maxDate = campo.maxDate;
+    }
+    if (campo.tipoUi === 'MultiSelect' || campo.tipoUi === 'selectMultiple') {
+      props.minimosRequeridos = campo.minimosRequeridos;
+    }
+    return props;
   }
 };

--- a/generators/gui/guiService.js
+++ b/generators/gui/guiService.js
@@ -65,9 +65,11 @@ module.exports = class guiService {
     campo.lowerCase = String.toCamelCase(campo.campo);
     campo.snakeCase = String.toSnakeCase(campo.campo);
     campo.dashCase = String.toDashCase(campo.campo);
+    campo.constantCase = String.toConstantCase(campo.campo);
     campo.clientType = this.resolveClientType(campo.tipoUi);
     campo.clientDefaultValue = this.resolveDefaultValue(campo.tipoUi);
     campo.feedback = campo.feedback ? campo.feedback : null;
+    campo.description = campo.descripcion ? campo.descripcion : null;
     campo.validations = this.resolveValidations(campo);
     return campo;
   }
@@ -129,11 +131,19 @@ module.exports = class guiService {
   static resolveValidations(campo) {
     let validations = {};
     validations.required = campo.requerido;
+    validations.requiredValue = campo.requerido;
+    validations.requiredMessage = campo.mensajeRequerido;
     if (campo.min) {
       validations.min = campo.min;
+      validations.minMessage = campo.mensajeMin;
     }
     if (campo.max) {
       validations.max = campo.max;
+      validations.maxMessage = campo.mensajeMax;
+    }
+    if (campo.regex) {
+      validations.regex = campo.regex;
+      validations.regexMessage = campo.mensajeRegex;
     }
     return validations;
   }

--- a/generators/gui/guiService.js
+++ b/generators/gui/guiService.js
@@ -18,9 +18,11 @@ module.exports = class guiService {
       let subseccion = String.toCamelCase(campo.subseccion);
       if (!secciones[seccion]) {
         secciones[seccion] = this.defaultSeccion(campo.seccion);
+        secciones[seccion].props.labelEn = campo.seccionEn;
       }
       if (!secciones[seccion][subseccion]) {
         secciones[seccion][subseccion] = this.defaultSubseccion(campo.subseccion);
+        secciones[seccion][subseccion].props.labelEn = campo.subseccionEn;
       }
       secciones[seccion][subseccion].campos.push(this.formatCampo(campo));
     });
@@ -62,6 +64,7 @@ module.exports = class guiService {
 
   static formatCampo(campo) {
     campo.label = campo.campo;
+    campo.labelEn = campo.campoEn;
     campo.pascalCase = String.toPascalCase(campo.campo);
     campo.lowerCase = String.toCamelCase(campo.campo);
     campo.snakeCase = String.toSnakeCase(campo.campo);
@@ -69,7 +72,8 @@ module.exports = class guiService {
     campo.constantCase = String.toConstantCase(campo.campo);
     campo.clientType = this.resolveClientType(campo.tipoUi);
     campo.clientDefaultValue = this.resolveDefaultValue(campo.tipoUi);
-    campo.description = campo.descripcion ? campo.descripcion : null;
+    campo.description = campo.descripcion;
+    campo.descriptionEn = campo.descripcionEn;
     campo.validations = this.resolveValidations(campo);
     campo.props = this.resolveProps(campo);
     return campo;

--- a/generators/gui/index.js
+++ b/generators/gui/index.js
@@ -79,11 +79,11 @@ module.exports = class extends Generator {
           process: function (content) {
             let regEx = new RegExp(Constants.ENTITY_TO_MENU, 'g');
             let entityToMenu = `
-                    <b-dropdown-item to="/${seccion.props.dashCase}" active-class="active">
-                      <span>${seccion.props.label}</span>
-                    </b-dropdown-item>
-                    ${Constants.ENTITY_TO_MENU}
-                    `;
+    <b-dropdown-item to="/${seccion.props.dashCase}" active-class="active">
+      <span v-text="$t('${seccion.props.dashCase}.title')">${seccion.props.label}</span>
+    </b-dropdown-item>
+    ${Constants.ENTITY_TO_MENU}
+    `;
             let newContent = content.toString().replace(regEx, entityToMenu);
             return newContent;
           },

--- a/generators/gui/index.js
+++ b/generators/gui/index.js
@@ -25,6 +25,7 @@ module.exports = class extends Generator {
     context.entitiesPath = this.destinationPath('src/main/webapp/app/router/entities.ts');
     context.mainPath = this.destinationPath('src/main/webapp/app/main.ts');
     context.entitiesMenuPath = this.destinationPath('src/main/webapp/app/entities/entities-menu.vue');
+    context.i18nPath = this.destinationPath('src/main/webapp/i18n');
     let campos = GuiService.resolveJson(context);
     let secciones = GuiService.resolveSecciones(campos);
     let seccionesOpt = this.config.get('secciones');
@@ -99,6 +100,12 @@ module.exports = class extends Generator {
 
       destination = context.modelDestinationPath + seccion.props.dashCase + '.model.ts';
       this.fs.copyTpl(this.templatePath('seccion.model.ts.ejs'), this.destinationPath(destination), templateVariables);
+
+      destination = context.i18nPath + '/es/' + seccion.props.dashCase + '.json';
+      this.fs.copyTpl(this.templatePath('seccion-es.json.ejs'), this.destinationPath(destination), templateVariables);
+
+      destination = context.i18nPath + '/en/' + seccion.props.dashCase + '.json';
+      this.fs.copyTpl(this.templatePath('seccion-en.json.ejs'), this.destinationPath(destination), templateVariables);
     }
     this.config.set('secciones', seccionesOpt);
     this.config.save();

--- a/generators/gui/templates/seccion-en.json.ejs
+++ b/generators/gui/templates/seccion-en.json.ejs
@@ -1,20 +1,20 @@
 {
   "<%= seccion.props.dashCase%>": {
-    "title": "<%= seccion.props.label%>",
-    "subtitle": "<%= seccion.props.label%>",
+    "title": "<%= seccion.props.labelEn%>",
+    "subtitle": "<%= seccion.props.labelEn%>",
     <%_ let subseccionComa = -1; _%>
     <%_ for (const mayBeSubseccion in seccion) { _%>
       <%_ if (mayBeSubseccion != 'props') { ++subseccionComa;_%>
         <%_ if (subseccionComa > 0) { _%>
     ,<% } %>
     "<%= seccion[mayBeSubseccion].props.dashCase %>": {
-      "title": "<%= seccion[mayBeSubseccion].props.label %>",
-      "subtitle": "<%= seccion[mayBeSubseccion].props.label %>",
+      "title": "<%= seccion[mayBeSubseccion].props.labelEn %>",
+      "subtitle": "<%= seccion[mayBeSubseccion].props.labelEn %>",
       "fields": {
       <%_ seccion[mayBeSubseccion].campos.forEach((campo, index) => { _%>
         "<%= campo.dashCase%>": {
-          "label": "<%= campo.label%>",
-          "description": "<%= campo.description%>",
+          "label": "<%= campo.labelEn%>",
+          "description": "<%= campo.descriptionEn%>",
           "validations": {
             "required": "The field {field} is required",
             "minMessage": "The number of characters must be at least of {min}",

--- a/generators/gui/templates/seccion-en.json.ejs
+++ b/generators/gui/templates/seccion-en.json.ejs
@@ -16,10 +16,10 @@
           "label": "<%= campo.labelEn%>",
           "description": "<%= campo.descriptionEn%>",
           "validations": {
-            "required": "The field {field} is required",
+            "required": "The field <%= campo.label%> is required",
             "minMessage": "The number of characters must be at least of {min}",
             "maxMessage": "The number of characters must be as much as {max}",
-            "regexMessage": "Invalid {field} format"
+            "regexMessage": "Invalid <%= campo.label%> format"
           }
         }<% if ((seccion[mayBeSubseccion].campos.length -1) !== index ) { %>,<% } %>
       <%_ }) _%>

--- a/generators/gui/templates/seccion-en.json.ejs
+++ b/generators/gui/templates/seccion-en.json.ejs
@@ -1,0 +1,31 @@
+{
+  "<%= seccion.props.dashCase%>": {
+    "title": "<%= seccion.props.label%>",
+    "subtitle": "<%= seccion.props.label%>",
+    <%_ let subseccionComa = -1; _%>
+    <%_ for (const mayBeSubseccion in seccion) { _%>
+      <%_ if (mayBeSubseccion != 'props') { ++subseccionComa;_%>
+        <%_ if (subseccionComa > 0) { _%>
+    ,<% } %>
+    "<%= seccion[mayBeSubseccion].props.dashCase %>": {
+      "title": "<%= seccion[mayBeSubseccion].props.label %>",
+      "subtitle": "<%= seccion[mayBeSubseccion].props.label %>",
+      "fields": {
+      <%_ seccion[mayBeSubseccion].campos.forEach((campo, index) => { _%>
+        "<%= campo.dashCase%>": {
+          "label": "<%= campo.label%>",
+          "description": "<%= campo.description%>",
+          "validations": {
+            "required": "The field {field} is required",
+            "minMessage": "The number of characters must be at least of {min}",
+            "maxMessage": "The number of characters must be as much as {max}",
+            "regexMessage": "Invalid {field} format"
+          }
+        }<% if ((seccion[mayBeSubseccion].campos.length -1) !== index ) { %>,<% } %>
+      <%_ }) _%>
+      }
+    }
+      <%_ } _%>
+    <%_ } _%>
+  }
+}

--- a/generators/gui/templates/seccion-es.json.ejs
+++ b/generators/gui/templates/seccion-es.json.ejs
@@ -16,10 +16,10 @@
           "label": "<%= campo.label%>",
           "description": "<%= campo.description%>",
           "validations": {
-            "required": "El campo {field} es requerido",
+            "required": "El campo <%= campo.label%> es requerido",
             "minMessage": "El número de caracteres debe ser de al menos {min}",
             "maxMessage": "El número de caracteres debe ser máximo de {max}",
-            "regexMessage": "Formato de {field} inválido"
+            "regexMessage": "Formato de <%= campo.label%> inválido"
           }
         }<% if ((seccion[mayBeSubseccion].campos.length -1) !== index ) { %>,<% } %>
       <%_ }) _%>

--- a/generators/gui/templates/seccion-es.json.ejs
+++ b/generators/gui/templates/seccion-es.json.ejs
@@ -1,0 +1,31 @@
+{
+  "<%= seccion.props.dashCase%>": {
+    "title": "<%= seccion.props.label%>",
+    "subtitle": "<%= seccion.props.label%>",
+    <%_ let subseccionComa = -1; _%>
+    <%_ for (const mayBeSubseccion in seccion) { _%>
+      <%_ if (mayBeSubseccion != 'props') { ++subseccionComa;_%>
+        <%_ if (subseccionComa > 0) { _%>
+    ,<% } %>
+    "<%= seccion[mayBeSubseccion].props.dashCase %>": {
+      "title": "<%= seccion[mayBeSubseccion].props.label %>",
+      "subtitle": "<%= seccion[mayBeSubseccion].props.label %>",
+      "fields": {
+      <%_ seccion[mayBeSubseccion].campos.forEach((campo, index) => { _%>
+        "<%= campo.dashCase%>": {
+          "label": "<%= campo.label%>",
+          "description": "<%= campo.description%>",
+          "validations": {
+            "required": "El campo {field} es requerido",
+            "minMessage": "El número de caracteres debe ser de al menos {min}",
+            "maxMessage": "El número de caracteres debe ser máximo de {max}",
+            "regexMessage": "Formato de {field} inválido"
+          }
+        }<% if ((seccion[mayBeSubseccion].campos.length -1) !== index ) { %>,<% } %>
+      <%_ }) _%>
+      }
+    }
+      <%_ } _%>
+    <%_ } _%>
+  }
+}

--- a/generators/gui/templates/seccion.component.ts.ejs
+++ b/generators/gui/templates/seccion.component.ts.ejs
@@ -59,15 +59,18 @@ export default class <%= seccion.props.pascalCase%>Component extends Vue {
   <%_ for (const mayBeSubseccion in seccion) { _%>
     <%_ if (mayBeSubseccion != 'props') { _%>
         <%_ seccion[mayBeSubseccion].campos.forEach(campo => { _%>
+          <%_ if (campo.tipoUi === 'selectMany' || campo.tipoUi === 'selectMultiple') { _%>
+  public selected<%= campo.pascalCase%> = [];
+          <%_ } _%>
           <%_ if (campo.tipoUi === 'selectOne' || campo.tipoUi === 'selectMany' || campo.tipoUi === 'selectMultiple') { _%>
-            public <%= campo.camelCase%>Options = [
-              { value: null, text: 'Seleccione <%= campo.label%>', disabled: true },
-              { value: '<%= campo.camelCase%>1', text: '<%= campo.label%> 1' },
-              { value: '<%= campo.camelCase%>2', text: '<%= campo.label%> 2' },
-              { value: '<%= campo.camelCase%>3', text: '<%= campo.label%> 3' },
-              { value: '<%= campo.camelCase%>4', text: '<%= campo.label%> 4' },
-              { value: '<%= campo.camelCase%>5', text: '<%= campo.label%> 5' }
-            ];
+  public <%= campo.camelCase%>Options = [
+    { value: null, text: 'Seleccione <%= campo.label%>', disabled: true },
+    { value: '<%= campo.camelCase%>1', text: '<%= campo.label%> 1' },
+    { value: '<%= campo.camelCase%>2', text: '<%= campo.label%> 2' },
+    { value: '<%= campo.camelCase%>3', text: '<%= campo.label%> 3' },
+    { value: '<%= campo.camelCase%>4', text: '<%= campo.label%> 4' },
+    { value: '<%= campo.camelCase%>5', text: '<%= campo.label%> 5' },
+  ];
           <%_ } _%>
         <%_ }); _%>
     <%_ } _%>

--- a/generators/gui/templates/seccion.component.ts.ejs
+++ b/generators/gui/templates/seccion.component.ts.ejs
@@ -4,7 +4,20 @@ import AlertService from '@/shared/alert/alert.service';
 
 import { I<%= seccion.props.pascalCase%>, <%= seccion.props.pascalCase%> } from '@/shared/model/msPerfil/<%= seccion.props.dashCase%>.model';
 import <%= seccion.props.pascalCase%>Service from './<%= seccion.props.dashCase%>.service';
-import { required, minLength, maxLength } from 'vuelidate/lib/validators';
+import { required, minLength, maxLength, helpers } from 'vuelidate/lib/validators';
+
+<%_ for (const mayBeSubseccion in seccion) { _%>
+  <%_ if (mayBeSubseccion != 'props') { _%>
+    <%_ seccion[mayBeSubseccion].campos.forEach(campo => { _%>
+      <%_ if (campo.validations.regex) { _%>
+const <%= campo.constantCase%> = helpers.regex(
+  '<%=campo.lowerCase%>',
+  <%=campo.validations.regex%>
+);
+        <%_ } _%>
+    <%_ }); _%>
+  <%_ } _%>
+<%_ } _%>
 
 const validations: any = {
 
@@ -21,6 +34,9 @@ const validations: any = {
       <%_ } _%>
       <%_ if (campo.validations.max) { _%>
       max: maxLength(<%= campo.validations.max%>),
+      <%_ } _%>
+      <%_ if (campo.validations.regex) { _%>
+      <%= campo.constantCase%>,
       <%_ } _%>
     },
   <%_ }); _%>

--- a/generators/gui/templates/seccion.component.ts.ejs
+++ b/generators/gui/templates/seccion.component.ts.ejs
@@ -59,6 +59,12 @@ export default class <%= seccion.props.pascalCase%>Component extends Vue {
   <%_ for (const mayBeSubseccion in seccion) { _%>
     <%_ if (mayBeSubseccion != 'props') { _%>
         <%_ seccion[mayBeSubseccion].campos.forEach(campo => { _%>
+          <%_ if (campo.tipoUi === 'Date') { _%>
+            <%_ if (campo.props) { _%>
+  public minDate<%= campo.pascalCase%> = new Date('<%=campo.props.minDate%>');
+  public maxDate<%= campo.pascalCase%> = new Date('<%=campo.props.maxDate%>');
+            <%_ } _%>
+          <%_ } _%>
           <%_ if (campo.tipoUi === 'selectMany' || campo.tipoUi === 'selectMultiple') { _%>
   public selected<%= campo.pascalCase%> = [];
           <%_ } _%>

--- a/generators/gui/templates/seccion.component.ts.ejs
+++ b/generators/gui/templates/seccion.component.ts.ejs
@@ -30,10 +30,10 @@ const validations: any = {
       required,
       <%_ }_%>
       <%_ if (campo.validations.min) { _%>
-      min: minLength(<%= campo.validations.min%>),
+      minLength: minLength(<%= campo.validations.min%>),
       <%_ } _%>
       <%_ if (campo.validations.max) { _%>
-      max: maxLength(<%= campo.validations.max%>),
+      maxLength: maxLength(<%= campo.validations.max%>),
       <%_ } _%>
       <%_ if (campo.validations.regex) { _%>
       <%= campo.constantCase%>,
@@ -61,7 +61,7 @@ export default class <%= seccion.props.pascalCase%>Component extends Vue {
         <%_ seccion[mayBeSubseccion].campos.forEach(campo => { _%>
           <%_ if (campo.tipoUi === 'selectOne' || campo.tipoUi === 'selectMany' || campo.tipoUi === 'selectMultiple') { _%>
             public <%= campo.camelCase%>Options = [
-              { value: null, text: 'Seleccione <%= campo.label%>' },
+              { value: null, text: 'Seleccione <%= campo.label%>', disabled: true },
               { value: '<%= campo.camelCase%>1', text: '<%= campo.label%> 1' },
               { value: '<%= campo.camelCase%>2', text: '<%= campo.label%> 2' },
               { value: '<%= campo.camelCase%>3', text: '<%= campo.label%> 3' },

--- a/generators/gui/templates/seccion.component.ts.ejs
+++ b/generators/gui/templates/seccion.component.ts.ejs
@@ -4,15 +4,26 @@ import AlertService from '@/shared/alert/alert.service';
 
 import { I<%= seccion.props.pascalCase%>, <%= seccion.props.pascalCase%> } from '@/shared/model/msPerfil/<%= seccion.props.dashCase%>.model';
 import <%= seccion.props.pascalCase%>Service from './<%= seccion.props.dashCase%>.service';
+import { required, minLength, maxLength } from 'vuelidate/lib/validators';
 
 const validations: any = {
 
   <%= seccion.props.camelCase%>: {
   <%_ for (const mayBeSubseccion in seccion) { _%>
     <%_ if (mayBeSubseccion != 'props') { _%>
-        <%_ seccion[mayBeSubseccion].campos.forEach(campo => { _%>
-          <%= campo.camelCase%>: {},
-        <%_ }); _%>
+  <%_ seccion[mayBeSubseccion].campos.forEach(campo => { _%>
+    <%= campo.camelCase%>: {
+      <%_ if (campo.validations.required) { _%>
+      required,
+      <%_ }_%>
+      <%_ if (campo.validations.min) { _%>
+      min: minLength(<%= campo.validations.min%>),
+      <%_ } _%>
+      <%_ if (campo.validations.max) { _%>
+      max: maxLength(<%= campo.validations.max%>),
+      <%_ } _%>
+    },
+  <%_ }); _%>
     <%_ } _%>
   <%_ } _%>
   },

--- a/generators/gui/templates/seccion.vue.ejs
+++ b/generators/gui/templates/seccion.vue.ejs
@@ -2,9 +2,9 @@
   <b-row class="row mb-5">
     <b-col md="12">
       <header class="bx-header-title">
-        <h2 id="<%= seccion.props.dashCase %>-id">
+        <h2 id="<%= seccion.props.dashCase %>-id" v-text="$t('<%= seccion.props.dashCase%>.title')">
           <%= seccion.props.label%>
-          <small><%= seccion.props.label%></small>
+          <small v-text="$t('<%= seccion.props.dashCase%>.subtitle')"><%= seccion.props.label%></small>
         </h2>
         <div class="header-title-line"></div>
       </header>
@@ -16,11 +16,12 @@
     </b-col>
 <%_ for (const mayBeSubseccion in seccion) { _%>
   <%_ if (mayBeSubseccion != 'props') { _%>
+    <%_ let pathSubseccion = seccion.props.dashCase + '.' + seccion[mayBeSubseccion].props.dashCase; _%>
     <b-col md="12">
       <header class="mt-5 bx-header-title">
-        <h3 id="<%= seccion[mayBeSubseccion].props.dashCase %>-id">
+        <h3 id="<%= seccion[mayBeSubseccion].props.dashCase %>-id" v-text="$t('<%= pathSubseccion %>.title')">
           <%= seccion[mayBeSubseccion].props.label %>
-          <small><%= seccion[mayBeSubseccion].props.label %></small>
+          <small v-text="$t('<%= pathSubseccion %>.subtitle')"><%= seccion[mayBeSubseccion].props.label %></small>
         </h3>
         <div class="header-title-line"></div>
       </header>
@@ -30,56 +31,56 @@
      <%_ if (campo.tipoUi === 'text') { _%>
       <input-text
         id="<%= seccion.props.dashCase%>-<%= campo.dashCase%>-id"
-        label="<%= campo.label %>"
-        description="<%=campo.description%>"
         v-model="$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$model"
+        :label="$t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.label')"
+        :description="$t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.description')"
         :readonly="false"
+        :required="<%= campo.validations.required %>"
         :valid="$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$dirty ? !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$error : null"
-        :objectFeedback="{
+        :validationsCommons="{
           <%_ if (campo.validations.required) { _%>
-          required: true,
           requiredValue: !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.required,
-          requiredMessaje: '<%=campo.validations.requiredMessage,%>',
+          requiredMessage: $t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.validations.required', { field: '<%= campo.label%>' }),
           <%_ } _%>
           <%_ if (campo.validations.min) { _%>
           minValue: !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.minLength,
-          minMessaje: '<%=campo.validations.minMessage,%>',
+          minMessage: $t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.validations.minMessage', { min: '<%=campo.validations.min%>' }),
           <%_ } _%>
           <%_ if (campo.validations.max) { _%>
           maxValue: !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.maxLength,
-          maxMessaje: '<%=campo.validations.maxMessage,%>',
+          maxMessage: $t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.validations.maxMessage', { max: '<%=campo.validations.max%>' }),
           <%_ } _%>
           <%_ if (campo.validations.regex) { _%>
           regexValue: !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.<%= campo.constantCase%>,
-          regexMessaje: '<%=campo.validations.regexMessage,%>',
+          regexMessage: $t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.validations.regexMessage', { field: '<%= campo.label%>' }),
           <%_ } _%>
         }"
       />
       <%_ } else if (campo.tipoUi === 'TextArea') { _%>
       <input-text-area
         id="<%= seccion.props.dashCase%>-<%= campo.dashCase%>-id"
-        label="<%= campo.label %>"
-        description="<%=campo.description %>"
         v-model="$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$model"
+        :label="$t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.label')"
+        :description="$t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.description')"
         :readonly="false"
+        :required="<%= campo.validations.required %>"
         :valid="$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$dirty ? !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$error : null"
-        :objectFeedback="{
+        :validationsCommons="{
           <%_ if (campo.validations.required) { _%>
-          required: true,
           requiredValue: !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.required,
-          requiredMessaje: '<%=campo.validations.requiredMessage,%>',
+          requiredMessage: $t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.validations.required', { field: '<%= campo.label%>' }),
           <%_ } _%>
           <%_ if (campo.validations.min) { _%>
           minValue: !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.minLength,
-          minMessaje: '<%=campo.validations.minMessage,%>',
+          minMessage: $t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.validations.minMessage', { min: '<%=campo.validations.min%>' }),
           <%_ } _%>
           <%_ if (campo.validations.max) { _%>
           maxValue: !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.maxLength,
-          maxMessaje: '<%=campo.validations.maxMessage,%>',
+          maxMessage: $t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.validations.maxMessage', { max: '<%=campo.validations.max%>' }),
           <%_ } _%>
           <%_ if (campo.validations.regex) { _%>
           regexValue: !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.<%= campo.constantCase%>,
-          regexMessaje: '<%=campo.validations.regexMessage,%>',
+          regexMessage: $t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.validations.regexMessage', { field: '<%= campo.label%>' }),
           <%_ } _%>
         }"
         <%_ if (campo.props) { _%>
@@ -89,25 +90,25 @@
       <%_ } else if (campo.tipoUi === 'Radio Button') { _%>
       <input-boolean
         id="<%= seccion.props.dashCase%>-<%= campo.dashCase%>-id"
-        label="<%= campo.label %>"
         v-model="$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$model"
+        :label="$t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.label')"
         :readonly="false"
         :valid="!$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$invalid"
       />
       <%_ } else if (campo.tipoUi === 'Date') { _%>
       <input-date
         id="<%= seccion.props.dashCase%>-<%= campo.dashCase%>-id"
-        label="<%= campo.label %>"
-        description="<%=campo.description %>"
-        placeholder="<%=campo.description %>"
         v-model="$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$model"
+        :label="$t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.label')"
+        :description="$t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.description')"
+        :placeholder="$t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.description')"
         :readonly="false"
+        :required="<%= campo.validations.required %>"
         :valid="$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$dirty ? !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$error : null"
-        :objectFeedback="{
+        :validationsCommons="{
           <%_ if (campo.validations.required) { _%>
-          required: true,
           requiredValue: !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.required,
-          requiredMessaje: '<%=campo.validations.requiredMessage,%>',
+          requiredMessage: $t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.validations.required', { field: '<%= campo.label%>' }),
           <%_ } _%>
         }"
         <%_ if (campo.props) { _%>
@@ -118,29 +119,37 @@
       <%_ } else if (campo.tipoUi === 'selectOne') { _%>
       <input-select-one
         id="<%= seccion.props.dashCase%>-<%= campo.dashCase%>-id"
-        label="<%= campo.label %>"
-        description="<%=campo.description %>"
         v-model="$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$model"
-        :readonly="false"
+        :label="$t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.label')"
+        :description="$t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.description')"
         :options="<%= campo.camelCase%>Options"
+        :readonly="false"
+        :required="<%= campo.validations.required %>"
         :valid="$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$dirty ? !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$error : null"
-        :objectFeedback="{
+        :validationsCommons="{
           <%_ if (campo.validations.required) { _%>
-          required: true,
           requiredValue: !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.required,
-          requiredMessaje: '<%=campo.validations.requiredMessage,%>',
+          requiredMessage: $t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.validations.required', { field: '<%= campo.label%>' }),
           <%_ } _%>
         }"
       />
       <%_ } else if (campo.tipoUi === 'selectMultiple') { _%>
       <input-select-many
         id="<%= seccion.props.dashCase%>-<%= campo.dashCase%>-id"
-        label="<%= campo.label %>"
-        description="<%=campo.description %>"
         v-model="$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$model"
-        :readonly="false"
+        :label="$t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.label')"
+        :description="$t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.description')"
         :options="<%= campo.camelCase%>Options"
+        :markedSelections="selected"
+        :readonly="false"
+        :required="<%= campo.validations.required %>"
         :valid="$v.<%=seccion.props.camelCase%>.$dirty ? !$v.<%=seccion.props.camelCase%>.$error && <%=seccion.props.camelCase%>.<%= campo.camelCase%>.length >= <%=campo.props.minimosRequeridos%>: null"
+        :validationsCommons="{
+          <%_ if (campo.validations.required) { _%>
+          requiredValue: !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.required,
+          requiredMessage: $t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.validations.required', { field: '<%= campo.label%>' }),
+          <%_ } _%>
+        }"
       />
       <%_ } _%>
     <%_ }); _%>
@@ -157,7 +166,7 @@
         <span>Guardar</span>
       </b-button>
     </b-col>
-</b-row>
+  </b-row>
 </template>
 
 <script lang="ts" src="./<%= seccion.props.dashCase%>.component.ts"></script>

--- a/generators/gui/templates/seccion.vue.ejs
+++ b/generators/gui/templates/seccion.vue.ejs
@@ -32,8 +32,27 @@
         id="<%= seccion.props.dashCase%>-<%= campo.dashCase%>-id"
         label="<%= campo.label %>"
         v-model="$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$model"
-        :valid="!$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$invalid"
-        feedback="<%= campo.feedback %>"
+        :valid="$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$dirty ? !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$error : null"
+        description="<%=campo.description %>"
+        :objectFeedback="{
+          <%_ if (campo.validations.required) { _%>
+          required: true,
+          requiredValue: !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.required,
+          requiredMessaje: '<%=campo.validations.requiredMessage,%>',
+          <%_ } _%>
+          <%_ if (campo.validations.min) { _%>
+          minValue: !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.minLength,
+          minMessaje: '<%=campo.validations.minMessage,%>',
+          <%_ } _%>
+          <%_ if (campo.validations.max) { _%>
+          maxValue: !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.maxLength,
+          maxMessaje: '<%=campo.validations.maxMessage,%>',
+          <%_ } _%>
+          <%_ if (campo.validations.regex) { _%>
+          regexValue: !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.<%= campo.constantCase%>,
+          regexMessaje: '<%=campo.validations.regexMessage,%>',
+          <%_ } _%>
+        }"
       />
       <%_ } else if (campo.tipoUi === 'textArea') { _%>
       <input-text-area

--- a/generators/gui/templates/seccion.vue.ejs
+++ b/generators/gui/templates/seccion.vue.ejs
@@ -33,6 +33,7 @@
         label="<%= campo.label %>"
         v-model="$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$model"
         :valid="!$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$invalid"
+        feedback="<%= campo.feedback %>"
       />
       <%_ } else if (campo.tipoUi === 'textArea') { _%>
       <input-text-area

--- a/generators/gui/templates/seccion.vue.ejs
+++ b/generators/gui/templates/seccion.vue.ejs
@@ -17,7 +17,7 @@
 <%_ for (const mayBeSubseccion in seccion) { _%>
   <%_ if (mayBeSubseccion != 'props') { _%>
     <b-col md="12">
-      <header class="bx-header-title">
+      <header class="mt-5 bx-header-title">
         <h3 id="<%= seccion[mayBeSubseccion].props.dashCase %>-id">
           <%= seccion[mayBeSubseccion].props.label %>
           <small><%= seccion[mayBeSubseccion].props.label %></small>
@@ -31,9 +31,10 @@
       <input-text
         id="<%= seccion.props.dashCase%>-<%= campo.dashCase%>-id"
         label="<%= campo.label %>"
+        description="<%=campo.description%>"
         v-model="$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$model"
+        :readonly="false"
         :valid="$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$dirty ? !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$error : null"
-        description="<%=campo.description %>"
         :objectFeedback="{
           <%_ if (campo.validations.required) { _%>
           required: true,
@@ -54,42 +55,92 @@
           <%_ } _%>
         }"
       />
-      <%_ } else if (campo.tipoUi === 'textArea') { _%>
+      <%_ } else if (campo.tipoUi === 'TextArea') { _%>
       <input-text-area
         id="<%= seccion.props.dashCase%>-<%= campo.dashCase%>-id"
         label="<%= campo.label %>"
+        description="<%=campo.description %>"
         v-model="$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$model"
-        :valid="!$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$invalid"
+        :readonly="false"
+        :valid="$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$dirty ? !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$error : null"
+        :objectFeedback="{
+          <%_ if (campo.validations.required) { _%>
+          required: true,
+          requiredValue: !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.required,
+          requiredMessaje: '<%=campo.validations.requiredMessage,%>',
+          <%_ } _%>
+          <%_ if (campo.validations.min) { _%>
+          minValue: !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.minLength,
+          minMessaje: '<%=campo.validations.minMessage,%>',
+          <%_ } _%>
+          <%_ if (campo.validations.max) { _%>
+          maxValue: !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.maxLength,
+          maxMessaje: '<%=campo.validations.maxMessage,%>',
+          <%_ } _%>
+          <%_ if (campo.validations.regex) { _%>
+          regexValue: !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.<%= campo.constantCase%>,
+          regexMessaje: '<%=campo.validations.regexMessage,%>',
+          <%_ } _%>
+        }"
+        <%_ if (campo.props) { _%>
+        :maxCaracteres="<%=campo.props.maxCaracteres%>"
+        <%_ } _%>
       />
       <%_ } else if (campo.tipoUi === 'Radio Button') { _%>
       <input-boolean
         id="<%= seccion.props.dashCase%>-<%= campo.dashCase%>-id"
         label="<%= campo.label %>"
         v-model="$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$model"
+        :readonly="false"
         :valid="!$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$invalid"
       />
       <%_ } else if (campo.tipoUi === 'Date') { _%>
       <input-date
         id="<%= seccion.props.dashCase%>-<%= campo.dashCase%>-id"
         label="<%= campo.label %>"
+        description="<%=campo.description %>"
+        placeholder="<%=campo.description %>"
         v-model="$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$model"
-        :valid="!$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$invalid"
+        :readonly="false"
+        :valid="$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$dirty ? !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$error : null"
+        :objectFeedback="{
+          <%_ if (campo.validations.required) { _%>
+          required: true,
+          requiredValue: !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.required,
+          requiredMessaje: '<%=campo.validations.requiredMessage,%>',
+          <%_ } _%>
+        }"
+        <%_ if (campo.props) { _%>
+        :minDate="<%=campo.props.minDate%>"
+        :maxDate="<%=campo.props.maxDate%>"
+        <%_ } _%>
       />
       <%_ } else if (campo.tipoUi === 'selectOne') { _%>
       <input-select-one
         id="<%= seccion.props.dashCase%>-<%= campo.dashCase%>-id"
         label="<%= campo.label %>"
+        description="<%=campo.description %>"
         v-model="$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$model"
+        :readonly="false"
         :options="<%= campo.camelCase%>Options"
-        :valid="!$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$invalid"
+        :valid="$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$dirty ? !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$error : null"
+        :objectFeedback="{
+          <%_ if (campo.validations.required) { _%>
+          required: true,
+          requiredValue: !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.required,
+          requiredMessaje: '<%=campo.validations.requiredMessage,%>',
+          <%_ } _%>
+        }"
       />
       <%_ } else if (campo.tipoUi === 'selectMultiple') { _%>
       <input-select-many
         id="<%= seccion.props.dashCase%>-<%= campo.dashCase%>-id"
         label="<%= campo.label %>"
+        description="<%=campo.description %>"
         v-model="$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$model"
+        :readonly="false"
         :options="<%= campo.camelCase%>Options"
-        :valid="!$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$invalid"
+        :valid="$v.<%=seccion.props.camelCase%>.$dirty ? !$v.<%=seccion.props.camelCase%>.$error && <%=seccion.props.camelCase%>.<%= campo.camelCase%>.length >= <%=campo.props.minimosRequeridos%>: null"
       />
       <%_ } _%>
     <%_ }); _%>
@@ -101,7 +152,7 @@
         <font-awesome-icon icon="ban" class="mr-2"></font-awesome-icon>
         <span>Cancelar</span>
       </b-button>
-      <b-button variant="primary" size="lg">
+      <b-button @click="$v.<%= seccion.props.camelCase%>.$touch" variant="primary" size="lg">
         <font-awesome-icon icon="save" class="mr-2"></font-awesome-icon>
         <span>Guardar</span>
       </b-button>

--- a/generators/gui/templates/seccion.vue.ejs
+++ b/generators/gui/templates/seccion.vue.ejs
@@ -40,7 +40,7 @@
         :validationsCommons="{
           <%_ if (campo.validations.required) { _%>
           requiredValue: !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.required,
-          requiredMessage: $t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.validations.required', { field: '<%= campo.label%>' }),
+          requiredMessage: $t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.validations.required'),
           <%_ } _%>
           <%_ if (campo.validations.min) { _%>
           minValue: !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.minLength,
@@ -52,7 +52,7 @@
           <%_ } _%>
           <%_ if (campo.validations.regex) { _%>
           regexValue: !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.<%= campo.constantCase%>,
-          regexMessage: $t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.validations.regexMessage', { field: '<%= campo.label%>' }),
+          regexMessage: $t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.validations.regexMessage'),
           <%_ } _%>
         }"
       />
@@ -68,7 +68,7 @@
         :validationsCommons="{
           <%_ if (campo.validations.required) { _%>
           requiredValue: !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.required,
-          requiredMessage: $t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.validations.required', { field: '<%= campo.label%>' }),
+          requiredMessage: $t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.validations.required'),
           <%_ } _%>
           <%_ if (campo.validations.min) { _%>
           minValue: !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.minLength,
@@ -80,7 +80,7 @@
           <%_ } _%>
           <%_ if (campo.validations.regex) { _%>
           regexValue: !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.<%= campo.constantCase%>,
-          regexMessage: $t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.validations.regexMessage', { field: '<%= campo.label%>' }),
+          regexMessage: $t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.validations.regexMessage'),
           <%_ } _%>
         }"
         <%_ if (campo.props) { _%>
@@ -108,7 +108,7 @@
         :validationsCommons="{
           <%_ if (campo.validations.required) { _%>
           requiredValue: !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.required,
-          requiredMessage: $t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.validations.required', { field: '<%= campo.label%>' }),
+          requiredMessage: $t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.validations.required'),
           <%_ } _%>
         }"
         <%_ if (campo.props) { _%>
@@ -129,7 +129,7 @@
         :validationsCommons="{
           <%_ if (campo.validations.required) { _%>
           requiredValue: !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.required,
-          requiredMessage: $t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.validations.required', { field: '<%= campo.label%>' }),
+          requiredMessage: $t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.validations.required'),
           <%_ } _%>
         }"
       />
@@ -140,14 +140,16 @@
         :label="$t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.label')"
         :description="$t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.description')"
         :options="<%= campo.camelCase%>Options"
-        :markedSelections="selected"
+        :markedSelections="selected<%= campo.pascalCase%>"
         :readonly="false"
         :required="<%= campo.validations.required %>"
-        :valid="$v.<%=seccion.props.camelCase%>.$dirty ? !$v.<%=seccion.props.camelCase%>.$error && <%=seccion.props.camelCase%>.<%= campo.camelCase%>.length >= <%=campo.props.minimosRequeridos%>: null"
+        :valid="$v.<%=seccion.props.camelCase%>.<%= campo.camelCase%>.$dirty ?
+          !$v.<%=seccion.props.camelCase%>.<%= campo.camelCase%>.$error && <%=seccion.props.camelCase%>.<%= campo.camelCase%>.length >= <%=campo.props.minimosRequeridos%> : 
+          null"
         :validationsCommons="{
           <%_ if (campo.validations.required) { _%>
           requiredValue: !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.required,
-          requiredMessage: $t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.validations.required', { field: '<%= campo.label%>' }),
+          requiredMessage: $t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.validations.required'),
           <%_ } _%>
         }"
       />

--- a/generators/gui/templates/seccion.vue.ejs
+++ b/generators/gui/templates/seccion.vue.ejs
@@ -112,8 +112,8 @@
           <%_ } _%>
         }"
         <%_ if (campo.props) { _%>
-        :minDate="<%=campo.props.minDate%>"
-        :maxDate="<%=campo.props.maxDate%>"
+        :minDate="minDate<%= campo.pascalCase%>"
+        :maxDate="maxDate<%= campo.pascalCase%>"
         <%_ } _%>
       />
       <%_ } else if (campo.tipoUi === 'selectOne') { _%>

--- a/generators/util/strings.js
+++ b/generators/util/strings.js
@@ -33,4 +33,8 @@ module.exports = class Strings {
   static toSnakeCase(string) {
     return changeCase.snakeCase(this.normalize(string));
   }
+
+  static toConstantCase(string) {
+    return changeCase.constantCase(this.normalize(string));
+  }
 };

--- a/ui-descripcion.json
+++ b/ui-descripcion.json
@@ -15,11 +15,8 @@
     "min": 5,
     "max": 18,
     "descripcion": "Ingrese su CURP (Clave Única de Registro de Población)",
-    "mensajeRequerido": "Campo requerido",
-    "mensajeMin": "El tamaño del campo CURP no puede ser menor a 18 caracteres.",
-    "mensajeMax": "El tamaño del campo CURP no puede ser mayor a 18 caracteres.",
-    "regex": "/^[A-Z]{1}[AEIOU]{1}[A-Z]{2}[0-9]{2}(0[1-9]|1[0-2])(0[1-9]|1[0-9]|2[0-9]|3[0-1])[HM]{1}(AS|BC|BS|CC|CS|CH|CL|CM|DF|DG|GT|GR|HG|JC|MC|MN|MS|NT|NL|OC|PL|QT|QR|SP|SL|SR|TC|TS|TL|VZ|YN|ZS|NE)[B-DF-HJ-NP-TV-Z]{3}[0-9A-Z]{1}[0-9]{1}$/",
-    "mensajeRegex": "Curp Inválido"
+    "descripcionEn": "Type your CURP (Clave Única de Registro de Población)",
+    "regex": "/^[A-Z]{1}[AEIOU]{1}[A-Z]{2}[0-9]{2}(0[1-9]|1[0-2])(0[1-9]|1[0-9]|2[0-9]|3[0-1])[HM]{1}(AS|BC|BS|CC|CS|CH|CL|CM|DF|DG|GT|GR|HG|JC|MC|MN|MS|NT|NL|OC|PL|QT|QR|SP|SL|SR|TC|TS|TL|VZ|YN|ZS|NE)[B-DF-HJ-NP-TV-Z]{3}[0-9A-Z]{1}[0-9]{1}$/"
   },
   {
     "orden": 2,
@@ -35,8 +32,7 @@
     "tipoUi": "text",
     "opciones": "",
     "min": 3,
-    "max": 59,
-    "feedback": "Información inválida"
+    "max": 59
   },
   {
     "orden": 3,
@@ -52,8 +48,7 @@
     "tipoUi": "text",
     "opciones": "",
     "min": 8,
-    "max": 13,
-    "feedback": "Información inválida"
+    "max": 13
   },
   {
     "orden": 5,
@@ -69,7 +64,9 @@
     "tipoUi": "Date",
     "opciones": "",
     "min": 8,
-    "max": 19
+    "max": 19,
+    "minDate": "2000-12-30",
+    "maxDate": "2022-12-30"
   },
   {
     "orden": 6,
@@ -101,7 +98,8 @@
     "tipoUi": "selectMultiple",
     "opciones": "",
     "min": "",
-    "max": ""
+    "max": "",
+    "minimosRequeridos": 2
   },
   {
     "orden": 13,
@@ -146,10 +144,11 @@
     "subseccion": "Domicilio Residencia (requerido)",
     "tipoDato": "string",
     "requerido": false,
-    "tipoUi": "text",
+    "tipoUi": "TextArea",
     "opciones": "",
     "min": "",
-    "max": ""
+    "max": "",
+    "maxCaracteres": 100
   },
   {
     "orden": 85,

--- a/ui-descripcion.json
+++ b/ui-descripcion.json
@@ -13,7 +13,8 @@
     "tipoUi": "text",
     "opciones": "",
     "min": 5,
-    "max": 18
+    "max": 18,
+    "feedback": "Información inválida"
   },
   {
     "orden": 2,
@@ -29,7 +30,8 @@
     "tipoUi": "text",
     "opciones": "",
     "min": 3,
-    "max": 59
+    "max": 59,
+    "feedback": "Información inválida"
   },
   {
     "orden": 3,
@@ -45,7 +47,8 @@
     "tipoUi": "text",
     "opciones": "",
     "min": 8,
-    "max": 13
+    "max": 13,
+    "feedback": "Información inválida"
   },
   {
     "orden": 5,
@@ -173,7 +176,8 @@
     "tipoUi": "text",
     "opciones": "",
     "min": 8,
-    "max": 23
+    "max": 23,
+    "feedback": "Información inválida"
   },
   {
     "orden": 87,

--- a/ui-descripcion.json
+++ b/ui-descripcion.json
@@ -14,7 +14,12 @@
     "opciones": "",
     "min": 5,
     "max": 18,
-    "feedback": "Información inválida"
+    "descripcion": "Ingrese su CURP (Clave Única de Registro de Población)",
+    "mensajeRequerido": "Campo requerido",
+    "mensajeMin": "El tamaño del campo CURP no puede ser menor a 18 caracteres.",
+    "mensajeMax": "El tamaño del campo CURP no puede ser mayor a 18 caracteres.",
+    "regex": "/^[A-Z]{1}[AEIOU]{1}[A-Z]{2}[0-9]{2}(0[1-9]|1[0-2])(0[1-9]|1[0-9]|2[0-9]|3[0-1])[HM]{1}(AS|BC|BS|CC|CS|CH|CL|CM|DF|DG|GT|GR|HG|JC|MC|MN|MS|NT|NL|OC|PL|QT|QR|SP|SL|SR|TC|TS|TL|VZ|YN|ZS|NE)[B-DF-HJ-NP-TV-Z]{3}[0-9A-Z]{1}[0-9]{1}$/",
+    "mensajeRegex": "Curp Inválido"
   },
   {
     "orden": 2,


### PR DESCRIPTION
Modifica `seccion.component` y `seccion.vue` para agregar validaciones `required, min, max`.  Se movió la indentación para cumplir con reglas de linter.

Un ejemplo del resultado generado es:
```
const validations: any = {

  datosGenerales: {
    curp: {
      required,
      min: minLength(5),
      max: maxLength(18),
    },
    nombre: {
      required,
      min: minLength(3),
      max: maxLength(59),
    },
    primerApellido: {
      required,
      min: minLength(8),
      max: maxLength(13),
    },
    fechaNacimiento: {
      required,
      min: minLength(8),
      max: maxLength(19),
    },
    sexo: {
      required,
    },
    estadoConyugal: {
      required,
    },
    tipoBeneficio: {
    },
    tipoAsentamiento: {
    },
    nombreAsentamiento: {
    },
  },
};
```