### PR TITLE
feat: tooltips

### DIFF
--- a/generators/gui/guiService.js
+++ b/generators/gui/guiService.js
@@ -64,6 +64,7 @@ module.exports = class guiService {
   static formatCampo(campo) {
     campo.label = campo.campo;
     campo.labelEn = campo.campoEn;
+    campo.camelCase = String.toCamelCase(campo.campo);
     campo.pascalCase = String.toPascalCase(campo.campo);
     campo.lowerCase = String.toCamelCase(campo.campo);
     campo.snakeCase = String.toSnakeCase(campo.campo);

--- a/generators/gui/templates/seccion-en.json.ejs
+++ b/generators/gui/templates/seccion-en.json.ejs
@@ -15,6 +15,7 @@
         "<%= campo.dashCase%>": {
           "label": "<%= campo.labelEn%>",
           "description": "<%= campo.descriptionEn%>",
+          "tooltip": "<%= campo.tooltipEn%>",
           "validations": {
             "required": "The field <%= campo.label%> is required",
             "minMessage": "The number of characters must be at least of {min}",

--- a/generators/gui/templates/seccion-es.json.ejs
+++ b/generators/gui/templates/seccion-es.json.ejs
@@ -15,6 +15,7 @@
         "<%= campo.dashCase%>": {
           "label": "<%= campo.label%>",
           "description": "<%= campo.description%>",
+          "tooltip": "<%= campo.tooltip%>",
           "validations": {
             "required": "El campo <%= campo.label%> es requerido",
             "minMessage": "El número de caracteres debe ser de al menos {min}",

--- a/generators/gui/templates/seccion.vue.ejs
+++ b/generators/gui/templates/seccion.vue.ejs
@@ -34,6 +34,9 @@
         v-model="$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$model"
         :label="$t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.label')"
         :description="$t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.description')"
+        <%_ if (campo.tooltip) { _%>
+        :tooltip="$t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.tooltip')"
+        <%_ } _%>
         :readonly="false"
         :required="<%= campo.validations.required %>"
         :valid="$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$dirty ? !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$error : null"
@@ -62,6 +65,9 @@
         v-model="$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$model"
         :label="$t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.label')"
         :description="$t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.description')"
+        <%_ if (campo.tooltip) { _%>
+        :tooltip="$t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.tooltip')"
+        <%_ } _%>
         :readonly="false"
         :required="<%= campo.validations.required %>"
         :valid="$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$dirty ? !$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$error : null"
@@ -101,6 +107,9 @@
         v-model="$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$model"
         :label="$t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.label')"
         :description="$t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.description')"
+        <%_ if (campo.tooltip) { _%>
+        :tooltip="$t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.tooltip')"
+        <%_ } _%>
         :placeholder="$t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.description')"
         :readonly="false"
         :required="<%= campo.validations.required %>"
@@ -122,6 +131,9 @@
         v-model="$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$model"
         :label="$t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.label')"
         :description="$t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.description')"
+        <%_ if (campo.tooltip) { _%>
+        :tooltip="$t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.tooltip')"
+        <%_ } _%>
         :options="<%= campo.camelCase%>Options"
         :readonly="false"
         :required="<%= campo.validations.required %>"
@@ -139,6 +151,9 @@
         v-model="$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$model"
         :label="$t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.label')"
         :description="$t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.description')"
+        <%_ if (campo.tooltip) { _%>
+        :tooltip="$t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.tooltip')"
+        <%_ } _%>
         :options="<%= campo.camelCase%>Options"
         :markedSelections="selected<%= campo.pascalCase%>"
         :readonly="false"

--- a/generators/gui/templates/seccion.vue.ejs
+++ b/generators/gui/templates/seccion.vue.ejs
@@ -98,6 +98,9 @@
         id="<%= seccion.props.dashCase%>-<%= campo.dashCase%>-id"
         v-model="$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$model"
         :label="$t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.label')"
+        <%_ if (campo.tooltip) { _%>
+        :tooltip="$t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.tooltip')"
+        <%_ } _%>
         :readonly="false"
         :valid="!$v.<%= seccion.props.camelCase%>.<%= campo.camelCase%>.$invalid"
       />


### PR DESCRIPTION
Agrega propiedad tooltip a componentes `input-text, input-text-area, input-date, input-select-one. input-select-many, input-boolean` así como etiquetas para i18n. Lee las propiedades del archivo json `tooltip`, `tooltipEn` para agregarlas al i18n y componentes vue.