### PR TITLE
feat: agrega componente cards-list

### DIFF
--- a/generators/gui/guiService.js
+++ b/generators/gui/guiService.js
@@ -103,6 +103,11 @@ module.exports = class guiService {
     if (tipoUi === 'Radio Button' || tipoUi === 'Boolean') {
       return 'boolean';
     }
+
+    if (tipoUi === 'cardsList') {
+      return '[]';
+    }
+
     return 'string';
   }
 
@@ -129,6 +134,10 @@ module.exports = class guiService {
 
     if (tipoUi === 'Radio Button' || tipoUi === 'Boolean') {
       return 'false';
+    }
+
+    if (tipoUi === 'cardsList') {
+      return '[]';
     }
     return "''";
   }

--- a/generators/gui/templates/seccion.component.ts.ejs
+++ b/generators/gui/templates/seccion.component.ts.ejs
@@ -25,7 +25,7 @@ const validations: any = {
   <%_ for (const mayBeSubseccion in seccion) { _%>
     <%_ if (mayBeSubseccion != 'props') { _%>
   <%_ seccion[mayBeSubseccion].campos.forEach(campo => { _%>
-    <%= campo.camelCase%>: {
+    <%= campo.tipoUi === 'cardsList'? campo.camelCase + 'Items' :campo.camelCase%>: {
       <%_ if (campo.validations.required) { _%>
       required,
       <%_ }_%>
@@ -59,6 +59,9 @@ export default class <%= seccion.props.pascalCase%>Component extends Vue {
   <%_ for (const mayBeSubseccion in seccion) { _%>
     <%_ if (mayBeSubseccion != 'props') { _%>
         <%_ seccion[mayBeSubseccion].campos.forEach(campo => { _%>
+          <%_ if (campo.tipoUi === 'cardsList') { _%>
+  public <%= campo.camelCase%>Items: Array<any> = [];
+          <%_ } _%>
           <%_ if (campo.tipoUi === 'Date') { _%>
             <%_ if (campo.props) { _%>
   public minDate<%= campo.pascalCase%> = new Date('<%=campo.props.minDate%>');

--- a/generators/gui/templates/seccion.model.ts.ejs
+++ b/generators/gui/templates/seccion.model.ts.ejs
@@ -2,7 +2,7 @@ export interface I<%=seccionPascalCase%> {
     <%_ for (const mayBeSubseccion in seccion) { _%>
       <%_ if (mayBeSubseccion != 'props') { _%>
         <%_ seccion[mayBeSubseccion].campos.forEach(campo => { _%>
-    <%= campo.camelCase%>?: <%= campo.clientType%> | null;
+          <%= campo.tipoUi === 'cardsList'? campo.camelCase + 'Items' : campo.camelCase%>?: <%= campo.clientType%> | null;
         <%_ }); _%>
       <%_ } _%>
     <%_ } _%>
@@ -13,7 +13,7 @@ export class <%=seccionPascalCase%> implements I<%=seccionPascalCase%> {
     <%_ for (const mayBeSubseccion in seccion) { _%>
       <%_ if (mayBeSubseccion != 'props') { _%>
         <%_ seccion[mayBeSubseccion].campos.forEach(campo => { _%>
-    public <%= campo.camelCase%>?: <%= campo.clientType%> | null,
+    public <%= campo.tipoUi === 'cardsList'? campo.camelCase + 'Items' : campo.camelCase%>?: <%= campo.clientType%> | null,
         <%_ }); _%>
       <%_ } _%>
     <%_ } _%>
@@ -21,7 +21,11 @@ export class <%=seccionPascalCase%> implements I<%=seccionPascalCase%> {
     <%_ for (const mayBeSubseccion in seccion) { _%>
       <%_ if (mayBeSubseccion != 'props') { _%>
         <%_ seccion[mayBeSubseccion].campos.forEach(campo => { _%>
+          <%_ if (campo.tipoUi === 'cardsList') { _%>
+    this.<%= campo.camelCase%>Items = this.<%= campo.camelCase%>Items ?? <%- campo.clientDefaultValue%>;
+          <%_ } else { _%>
     this.<%= campo.camelCase%> = this.<%= campo.camelCase%> ?? <%- campo.clientDefaultValue%>;
+          <%_ } _%>
         <%_ }); _%>
       <%_ } _%>
     <%_ } _%>

--- a/generators/gui/templates/seccion.vue.ejs
+++ b/generators/gui/templates/seccion.vue.ejs
@@ -171,6 +171,11 @@
           <%_ } _%>
         }"
       />
+      <%_ } else if (campo.tipoUi === 'cardsList') { _%>
+        <cards-list
+          id="<%= seccion.props.dashCase%>-<%= campo.dashCase%>-id"
+          :items="<%= campo.camelCase%>Items"
+          :title="$t('<%= pathSubseccion %>.fields.<%= campo.dashCase%>.label')"/>
       <%_ } _%>
     <%_ }); _%>
     </b-col>


### PR DESCRIPTION
Agrega componente `cards-list` para definir una lista de `b-cards` utilizando un arreglo nombrado a partir de la etiqueta del campo+'Items'