### PR TITLE
feat: complementa refactoring

### DIFF
--- a/generators/gui/templates/api/api.yml.ejs
+++ b/generators/gui/templates/api/api.yml.ejs
@@ -22,7 +22,7 @@ components:
         nombre:
           description: Nombre de país
           type: string
-    File:
+    Archivo:
       description: Objeto genérico para hacer referencia a archivos
       type: object
       properties:

--- a/generators/gui/templates/fields/contacto.ejs
+++ b/generators/gui/templates/fields/contacto.ejs
@@ -1,0 +1,1 @@
+      <contacto id="<%= page.name.dashCase%>-<%= array.name.dashCase%>-id" title="<%= array.name.pascalCase%>" v-model="$v.<%= page.name.camelCase %>.<%= array.name.camelCase%>.$model" />

--- a/generators/gui/templates/fields/identificador.ejs
+++ b/generators/gui/templates/fields/identificador.ejs
@@ -1,0 +1,35 @@
+      <%_ let context = locals.context ? locals.context: false; _%>
+      <identificador
+        id="<%= page.name.dashCase%>-<%= campo.name.dashCase%>-id"
+        src=""
+        v-model="$v.<%= page.name.camelCase %>.<%= campo.name.camelCase%>.$model"
+        :label="$t('<%= pathSubseccion %>.<%= campo.name.dashCase%>.label')"
+        :description="$t('<%= pathSubseccion %>.<%= campo.name.dashCase%>.description')"
+        <%_ if (campo.tooltip) { _%>
+        :tooltip="$t('<%= pathSubseccion %>.<%= campo.name.dashCase%>.tooltip')"
+        <%_ } _%>
+        <%_ if (campo.placeHolder) { _%>
+        :placeholder="$t('<%= pathSubseccion %>.<%= campo.name.dashCase%>.placeHolder')"
+        <%_ } _%>
+        :readonly="<%= campo.validations.readonly %>"
+        :required="<%= campo.validations.required %>"
+        :valid="$v.<%= page.name.camelCase %>.<%= campo.name.camelCase%>.$dirty ? !$v.<%= page.name.camelCase %>.<%= campo.name.camelCase%>.$error : null"
+        :validationsCommons="{
+          <%_ if (campo.validations.required) { _%>
+          requiredValue: !$v.<%= page.name.camelCase %>.<%= campo.name.camelCase%>.required,
+          requiredMessage: $t('<%= pathSubseccion %>.<%= campo.name.dashCase%>.validations.required'),
+          <%_ } _%>
+          <%_ if (campo.validations.min) { _%>
+          minValue: !$v.<%= page.name.camelCase %>.<%= campo.name.camelCase%>.minLength,
+          minMessage: $t('<%= pathSubseccion %>.<%= campo.name.dashCase%>.validations.minMessage', { min: '<%=campo.validations.min%>' }),
+          <%_ } _%>
+          <%_ if (campo.validations.max) { _%>
+          maxValue: !$v.<%= page.name.camelCase %>.<%= campo.name.camelCase%>.maxLength,
+          maxMessage: $t('<%= pathSubseccion %>.<%= campo.name.dashCase%>.validations.maxMessage', { max: '<%=campo.validations.max%>' }),
+          <%_ } _%>
+          <%_ if (campo.validations.regex) { _%>
+          regexValue: !$v.<%= page.name.camelCase %>.<%= campo.name.camelCase%>.<%= campo.name.constantCase%>,
+          regexMessage: $t('<%= pathSubseccion %>.<%= campo.name.dashCase%>.validations.regexMessage'),
+          <%_ } _%>
+        }"
+      />

--- a/generators/gui/templates/fields/input-text-area.ejs
+++ b/generators/gui/templates/fields/input-text-area.ejs
@@ -26,7 +26,7 @@
           maxMessage: $t('<%= pathSubseccion %>.<%= campo.name.dashCase%>.validations.maxMessage', { max: '<%=campo.validations.max%>' }),
           <%_ } _%>
           <%_ if (campo.validations.regex) { _%>
-          regexValue: !$v.<%= page.name.camelCase%>.<%= campo.name.camelCase%>.<%= campo.constantCase%>,
+          regexValue: !$v.<%= page.name.camelCase%>.<%= campo.name.camelCase%>.<%= campo.name.constantCase%>,
           regexMessage: $t('<%= pathSubseccion %>.<%= campo.name.dashCase%>.validations.regexMessage'),
           <%_ } _%>
         }"

--- a/generators/gui/templates/fields/input-text.ejs
+++ b/generators/gui/templates/fields/input-text.ejs
@@ -27,7 +27,7 @@
           maxMessage: $t('<%= pathSubseccion %>.<%= campo.name.dashCase%>.validations.maxMessage', { max: '<%=campo.validations.max%>' }),
           <%_ } _%>
           <%_ if (campo.validations.regex) { _%>
-          regexValue: !$v.<%= page.name.camelCase %><%= campo.name.camelCase%>.<%= campo.constantCase%>,
+          regexValue: !$v.<%= page.name.camelCase %>.<%= campo.name.camelCase%>.<%= campo.name.constantCase%>,
           regexMessage: $t('<%= pathSubseccion %>.<%= campo.name.dashCase%>.validations.regexMessage'),
           <%_ } _%>
         }"

--- a/generators/gui/templates/i18n/page_es.json.ejs
+++ b/generators/gui/templates/i18n/page_es.json.ejs
@@ -11,10 +11,10 @@
       "tooltip": "<%= campo.tooltip%>",
       "placeHolder": "<%= campo.placeHolder%>",
       "validations": {
-        "required": "The field <%= campo.title%> is required",
-        "minMessage": "The number of characters must be at least of {min}",
-        "maxMessage": "The number of characters must be as much as {max}",
-        "regexMessage": "Invalid <%= campo.title%> format"
+        "required": "El campo <%= campo.title%> es requerido",
+        "minMessage": "El número de caracteres debe ser de al menos {min}",
+        "maxMessage": "El número de caracteres debe ser máximo de {max}",
+        "regexMessage": "Formato de <%= campo.title%> inválido"
       }<%_ if (campo.type === 'array') { _%>,
         <%_ let items = Object.keys(campo.items.properties); _%>
         <%_ items.forEach((key, idx) => { _%>

--- a/generators/gui/templates/page-arrays.ejs
+++ b/generators/gui/templates/page-arrays.ejs
@@ -1,3 +1,5 @@
 <%_ if (array.uiType === 'cards-list') { _%>
 <%- include('fields/cards-list', {page: page, array: array, pathSubseccion: pathSubseccion}); %>
+<%_ } else if (array.uiType === 'contacto') { _%>
+<%- include('fields/contacto', {page: page, array: array, pathSubseccion: pathSubseccion}); %>
 <%_ } _%>

--- a/generators/gui/templates/page-fields.ejs
+++ b/generators/gui/templates/page-fields.ejs
@@ -18,4 +18,6 @@
 <%- include('fields/input-text', {page: page, campo: campo, pathSubseccion: pathSubseccion}); %>
 <%_ } else if (campo.uiType === 'correo') { _%>
 <%- include('fields/input-text', {page: page, campo: campo, pathSubseccion: pathSubseccion}); %>
+<%_ } else if (campo.uiType === 'identificador') { _%>
+<%- include('fields/identificador', {page: page, campo: campo, pathSubseccion: pathSubseccion}); %>
 <%_ } _%>

--- a/generators/gui/templates/page.component.ts.ejs
+++ b/generators/gui/templates/page.component.ts.ejs
@@ -94,6 +94,7 @@ export default class <%= page.name.pascalCase%>Component extends Vue {
 
   mounted(): void {
     this.initCatalogos();
+    this.get();
   }
 
   public initCatalogos(): void {
@@ -107,6 +108,26 @@ export default class <%= page.name.pascalCase%>Component extends Vue {
       });
       <%_ } _%>
     <%_ }; _%>    
+  }
+
+  public get(): void {
+    this.<%= page.name.camelCase%>Api()
+      .get<%= page.name.pascalCase%>()
+      .then(res => {
+        this.<%= page.name.camelCase%> = res.data;
+      })
+      .catch(() => { });
+  }
+
+  public save(): void {
+    this.<%= page.name.camelCase%>Api()
+      .update<%= page.name.pascalCase%>ById(1, this.<%= page.name.camelCase%>)
+      .then(res => {
+        this.alertService().showSuccess(this, this.$t('global.messages.saved.detail', { section: this.$t('<%= page.name.dashCase%>.title') }).toString());
+      })
+      .catch(err => {
+        this.alertService().showError(this, this.$t('global.messages.error.saved', { section: this.$t('<%= page.name.dashCase%>.title') }).toString());
+      });
   }
 
   public previousState(): void {

--- a/generators/gui/templates/page.vue.ejs
+++ b/generators/gui/templates/page.vue.ejs
@@ -1,10 +1,5 @@
 <template>
   <b-row class="row mb-5">
-    <b-col md="12" class="mb-5">
-      <div class="alert alert-success">
-        <span>Alert basetemplate</span>
-      </div>
-    </b-col>
     <%_ let pathSubseccion = page.name.dashCase; _%>
     <b-col md="12">
       <header class="mt-5 bx-header-title">
@@ -29,7 +24,7 @@
         <font-awesome-icon icon="ban" class="mr-2"></font-awesome-icon>
         <span>Cancelar</span>
       </b-button>
-      <b-button @click="$v.<%= page.name.camelCase%>.$touch" variant="primary" size="lg">
+      <b-button @click="save" variant="primary" size="lg">
         <font-awesome-icon icon="save" class="mr-2"></font-awesome-icon>
         <span>Guardar</span>
       </b-button>


### PR DESCRIPTION
Complementa cambios a generador de pantallas:
- Agrega funciones get, save para consultar datos de sección
- Fix: corrige uso de regex en input-text, no estaba apuntando a la referencia correcta.
- Modifica el texto de alunas validaciones en español
- Agrega componente de contacto a generador cuando se identifica como array
- Agrega componente identificador de autor en page-fields
- Renombra esquema File por Archivo. Cuando se genera el cliente de open-api para typescript identifica a File como una interface de typescript y no asocia correctamente la definición (la toma como any). Se propone cambiar el nombre a Archivo.